### PR TITLE
endtime is an optional parameter

### DIFF
--- a/src/netatmo-setthermmode.html
+++ b/src/netatmo-setthermmode.html
@@ -20,7 +20,7 @@
       auth: { value: "", type: "netatmoconfig" },
       home_id: { value: '', required: true },
       mode: { value: '', required: true },
-      endtime: { value: '' }
+      endtime: { value: '', required: false }
     },
     inputs: 1,
     outputs: 1,


### PR DESCRIPTION
Hi,
this should fix the issue 

https://github.com/tvecera/node-red-contrib-netatmo-energy/issues/3

Could you please merge it?
Thanks
Claudio
