### PR TITLE
Netatmo API URL change.  -  Update netatmo-energy-api.js

### DIFF
--- a/src/netatmo-energy-api.js
+++ b/src/netatmo-energy-api.js
@@ -47,7 +47,7 @@ const EventEmitter = require("events").EventEmitter
 const request = require('request')
 const netatmoLogger = require("./netatmo-logger");
 
-const BASE_URL = 'https://api.netatmo.net'
+const BASE_URL = 'https://api.netatmo.com'
 const logger = new netatmoLogger()
 
 class Netatmo extends EventEmitter {


### PR DESCRIPTION
BASE_URL change on September 8, 2025
tested on my node-red instance, works fine

Important:

We will be retiring the domain api.netatmo.net and consolidating all API traffic under the existing domain api.netatmo.com on September 8, 2025.

Please update your applications to use api.netatmo.com exclusively before the above date. The structure and functionality of the API remain unchanged — only the domain name is affected.